### PR TITLE
Add support for go 1.9 t.Helper() method

### DIFF
--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -13,6 +13,10 @@ import (
 
 // Conditionf uses a Comparison to assert a complex condition.
 func Conditionf(t TestingT, comp Comparison, msg string, args ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	return Condition(t, comp, append([]interface{}{msg}, args...)...)
 }
 
@@ -25,6 +29,10 @@ func Conditionf(t TestingT, comp Comparison, msg string, args ...interface{}) bo
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Containsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	return Contains(t, s, contains, append([]interface{}{msg}, args...)...)
 }
 
@@ -35,6 +43,10 @@ func Containsf(t TestingT, s interface{}, contains interface{}, msg string, args
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	return Empty(t, object, append([]interface{}{msg}, args...)...)
 }
 
@@ -48,6 +60,10 @@ func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) boo
 // referenced values (as opposed to the memory addresses). Function equality
 // cannot be determined and will always fail.
 func Equalf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	return Equal(t, expected, actual, append([]interface{}{msg}, args...)...)
 }
 
@@ -59,6 +75,10 @@ func Equalf(t TestingT, expected interface{}, actual interface{}, msg string, ar
 //
 // Returns whether the assertion was successful (true) or not (false).
 func EqualErrorf(t TestingT, theError error, errString string, msg string, args ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	return EqualError(t, theError, errString, append([]interface{}{msg}, args...)...)
 }
 
@@ -69,6 +89,10 @@ func EqualErrorf(t TestingT, theError error, errString string, msg string, args 
 //
 // Returns whether the assertion was successful (true) or not (false).
 func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	return EqualValues(t, expected, actual, append([]interface{}{msg}, args...)...)
 }
 
@@ -81,6 +105,10 @@ func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg stri
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Errorf(t TestingT, err error, msg string, args ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	return Error(t, err, append([]interface{}{msg}, args...)...)
 }
 
@@ -90,16 +118,28 @@ func Errorf(t TestingT, err error, msg string, args ...interface{}) bool {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Exactlyf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	return Exactly(t, expected, actual, append([]interface{}{msg}, args...)...)
 }
 
 // Failf reports a failure through
 func Failf(t TestingT, failureMessage string, msg string, args ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	return Fail(t, failureMessage, append([]interface{}{msg}, args...)...)
 }
 
 // FailNowf fails test
 func FailNowf(t TestingT, failureMessage string, msg string, args ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	return FailNow(t, failureMessage, append([]interface{}{msg}, args...)...)
 }
 
@@ -109,6 +149,10 @@ func FailNowf(t TestingT, failureMessage string, msg string, args ...interface{}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Falsef(t TestingT, value bool, msg string, args ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	return False(t, value, append([]interface{}{msg}, args...)...)
 }
 
@@ -119,6 +163,10 @@ func Falsef(t TestingT, value bool, msg string, args ...interface{}) bool {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPBodyContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	return HTTPBodyContains(t, handler, method, url, values, str)
 }
 
@@ -129,6 +177,10 @@ func HTTPBodyContainsf(t TestingT, handler http.HandlerFunc, method string, url 
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPBodyNotContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	return HTTPBodyNotContains(t, handler, method, url, values, str)
 }
 
@@ -138,6 +190,10 @@ func HTTPBodyNotContainsf(t TestingT, handler http.HandlerFunc, method string, u
 //
 // Returns whether the assertion was successful (true, "error message %s", "formatted") or not (false).
 func HTTPErrorf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	return HTTPError(t, handler, method, url, values)
 }
 
@@ -147,6 +203,10 @@ func HTTPErrorf(t TestingT, handler http.HandlerFunc, method string, url string,
 //
 // Returns whether the assertion was successful (true, "error message %s", "formatted") or not (false).
 func HTTPRedirectf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	return HTTPRedirect(t, handler, method, url, values)
 }
 
@@ -156,6 +216,10 @@ func HTTPRedirectf(t TestingT, handler http.HandlerFunc, method string, url stri
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPSuccessf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	return HTTPSuccess(t, handler, method, url, values)
 }
 
@@ -163,6 +227,10 @@ func HTTPSuccessf(t TestingT, handler http.HandlerFunc, method string, url strin
 //
 //    assert.Implementsf(t, (*MyInterface, "error message %s", "formatted")(nil), new(MyObject))
 func Implementsf(t TestingT, interfaceObject interface{}, object interface{}, msg string, args ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	return Implements(t, interfaceObject, object, append([]interface{}{msg}, args...)...)
 }
 
@@ -172,11 +240,19 @@ func Implementsf(t TestingT, interfaceObject interface{}, object interface{}, ms
 //
 // Returns whether the assertion was successful (true) or not (false).
 func InDeltaf(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	return InDelta(t, expected, actual, delta, append([]interface{}{msg}, args...)...)
 }
 
 // InDeltaSlicef is the same as InDelta, except it compares two slices.
 func InDeltaSlicef(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	return InDeltaSlice(t, expected, actual, delta, append([]interface{}{msg}, args...)...)
 }
 
@@ -184,16 +260,28 @@ func InDeltaSlicef(t TestingT, expected interface{}, actual interface{}, delta f
 //
 // Returns whether the assertion was successful (true) or not (false).
 func InEpsilonf(t TestingT, expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	return InEpsilon(t, expected, actual, epsilon, append([]interface{}{msg}, args...)...)
 }
 
 // InEpsilonSlicef is the same as InEpsilon, except it compares each value from two slices.
 func InEpsilonSlicef(t TestingT, expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	return InEpsilonSlice(t, expected, actual, epsilon, append([]interface{}{msg}, args...)...)
 }
 
 // IsTypef asserts that the specified objects are of the same type.
 func IsTypef(t TestingT, expectedType interface{}, object interface{}, msg string, args ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	return IsType(t, expectedType, object, append([]interface{}{msg}, args...)...)
 }
 
@@ -203,6 +291,10 @@ func IsTypef(t TestingT, expectedType interface{}, object interface{}, msg strin
 //
 // Returns whether the assertion was successful (true) or not (false).
 func JSONEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	return JSONEq(t, expected, actual, append([]interface{}{msg}, args...)...)
 }
 
@@ -213,6 +305,10 @@ func JSONEqf(t TestingT, expected string, actual string, msg string, args ...int
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Lenf(t TestingT, object interface{}, length int, msg string, args ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	return Len(t, object, length, append([]interface{}{msg}, args...)...)
 }
 
@@ -222,6 +318,10 @@ func Lenf(t TestingT, object interface{}, length int, msg string, args ...interf
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Nilf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	return Nil(t, object, append([]interface{}{msg}, args...)...)
 }
 
@@ -234,6 +334,10 @@ func Nilf(t TestingT, object interface{}, msg string, args ...interface{}) bool 
 //
 // Returns whether the assertion was successful (true) or not (false).
 func NoErrorf(t TestingT, err error, msg string, args ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	return NoError(t, err, append([]interface{}{msg}, args...)...)
 }
 
@@ -246,6 +350,10 @@ func NoErrorf(t TestingT, err error, msg string, args ...interface{}) bool {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func NotContainsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	return NotContains(t, s, contains, append([]interface{}{msg}, args...)...)
 }
 
@@ -258,6 +366,10 @@ func NotContainsf(t TestingT, s interface{}, contains interface{}, msg string, a
 //
 // Returns whether the assertion was successful (true) or not (false).
 func NotEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	return NotEmpty(t, object, append([]interface{}{msg}, args...)...)
 }
 
@@ -270,6 +382,10 @@ func NotEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) 
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
 func NotEqualf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	return NotEqual(t, expected, actual, append([]interface{}{msg}, args...)...)
 }
 
@@ -279,6 +395,10 @@ func NotEqualf(t TestingT, expected interface{}, actual interface{}, msg string,
 //
 // Returns whether the assertion was successful (true) or not (false).
 func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	return NotNil(t, object, append([]interface{}{msg}, args...)...)
 }
 
@@ -288,6 +408,10 @@ func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) bo
 //
 // Returns whether the assertion was successful (true) or not (false).
 func NotPanicsf(t TestingT, f PanicTestFunc, msg string, args ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	return NotPanics(t, f, append([]interface{}{msg}, args...)...)
 }
 
@@ -298,6 +422,10 @@ func NotPanicsf(t TestingT, f PanicTestFunc, msg string, args ...interface{}) bo
 //
 // Returns whether the assertion was successful (true) or not (false).
 func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	return NotRegexp(t, rx, str, append([]interface{}{msg}, args...)...)
 }
 
@@ -308,11 +436,19 @@ func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ..
 //
 // Returns whether the assertion was successful (true) or not (false).
 func NotSubsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	return NotSubset(t, list, subset, append([]interface{}{msg}, args...)...)
 }
 
 // NotZerof asserts that i is not the zero value for its type and returns the truth.
 func NotZerof(t TestingT, i interface{}, msg string, args ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	return NotZero(t, i, append([]interface{}{msg}, args...)...)
 }
 
@@ -322,6 +458,10 @@ func NotZerof(t TestingT, i interface{}, msg string, args ...interface{}) bool {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Panicsf(t TestingT, f PanicTestFunc, msg string, args ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	return Panics(t, f, append([]interface{}{msg}, args...)...)
 }
 
@@ -332,6 +472,10 @@ func Panicsf(t TestingT, f PanicTestFunc, msg string, args ...interface{}) bool 
 //
 // Returns whether the assertion was successful (true) or not (false).
 func PanicsWithValuef(t TestingT, expected interface{}, f PanicTestFunc, msg string, args ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	return PanicsWithValue(t, expected, f, append([]interface{}{msg}, args...)...)
 }
 
@@ -342,6 +486,10 @@ func PanicsWithValuef(t TestingT, expected interface{}, f PanicTestFunc, msg str
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	return Regexp(t, rx, str, append([]interface{}{msg}, args...)...)
 }
 
@@ -352,6 +500,10 @@ func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...in
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Subsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	return Subset(t, list, subset, append([]interface{}{msg}, args...)...)
 }
 
@@ -361,6 +513,10 @@ func Subsetf(t TestingT, list interface{}, subset interface{}, msg string, args 
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Truef(t TestingT, value bool, msg string, args ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	return True(t, value, append([]interface{}{msg}, args...)...)
 }
 
@@ -370,10 +526,18 @@ func Truef(t TestingT, value bool, msg string, args ...interface{}) bool {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	return WithinDuration(t, expected, actual, delta, append([]interface{}{msg}, args...)...)
 }
 
 // Zerof asserts that i is the zero value for its type and returns the truth.
 func Zerof(t TestingT, i interface{}, msg string, args ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	return Zero(t, i, append([]interface{}{msg}, args...)...)
 }

--- a/assert/assertion_format.go.tmpl
+++ b/assert/assertion_format.go.tmpl
@@ -1,4 +1,8 @@
 {{.CommentFormat}}
 func {{.DocInfo.Name}}f(t TestingT, {{.ParamsFormat}}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	return {{.DocInfo.Name}}(t, {{.ForwardedParamsFormat}})
 }

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -13,11 +13,19 @@ import (
 
 // Condition uses a Comparison to assert a complex condition.
 func (a *Assertions) Condition(comp Comparison, msgAndArgs ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return Condition(a.t, comp, msgAndArgs...)
 }
 
 // Conditionf uses a Comparison to assert a complex condition.
 func (a *Assertions) Conditionf(comp Comparison, msg string, args ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return Conditionf(a.t, comp, msg, args...)
 }
 
@@ -30,6 +38,10 @@ func (a *Assertions) Conditionf(comp Comparison, msg string, args ...interface{}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Contains(s interface{}, contains interface{}, msgAndArgs ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return Contains(a.t, s, contains, msgAndArgs...)
 }
 
@@ -42,6 +54,10 @@ func (a *Assertions) Contains(s interface{}, contains interface{}, msgAndArgs ..
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Containsf(s interface{}, contains interface{}, msg string, args ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return Containsf(a.t, s, contains, msg, args...)
 }
 
@@ -52,6 +68,10 @@ func (a *Assertions) Containsf(s interface{}, contains interface{}, msg string, 
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return Empty(a.t, object, msgAndArgs...)
 }
 
@@ -62,6 +82,10 @@ func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) bool {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Emptyf(object interface{}, msg string, args ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return Emptyf(a.t, object, msg, args...)
 }
 
@@ -75,6 +99,10 @@ func (a *Assertions) Emptyf(object interface{}, msg string, args ...interface{})
 // referenced values (as opposed to the memory addresses). Function equality
 // cannot be determined and will always fail.
 func (a *Assertions) Equal(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return Equal(a.t, expected, actual, msgAndArgs...)
 }
 
@@ -86,6 +114,10 @@ func (a *Assertions) Equal(expected interface{}, actual interface{}, msgAndArgs 
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return EqualError(a.t, theError, errString, msgAndArgs...)
 }
 
@@ -97,6 +129,10 @@ func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) EqualErrorf(theError error, errString string, msg string, args ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return EqualErrorf(a.t, theError, errString, msg, args...)
 }
 
@@ -107,6 +143,10 @@ func (a *Assertions) EqualErrorf(theError error, errString string, msg string, a
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) EqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return EqualValues(a.t, expected, actual, msgAndArgs...)
 }
 
@@ -117,6 +157,10 @@ func (a *Assertions) EqualValues(expected interface{}, actual interface{}, msgAn
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) EqualValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return EqualValuesf(a.t, expected, actual, msg, args...)
 }
 
@@ -130,6 +174,10 @@ func (a *Assertions) EqualValuesf(expected interface{}, actual interface{}, msg 
 // referenced values (as opposed to the memory addresses). Function equality
 // cannot be determined and will always fail.
 func (a *Assertions) Equalf(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return Equalf(a.t, expected, actual, msg, args...)
 }
 
@@ -142,6 +190,10 @@ func (a *Assertions) Equalf(expected interface{}, actual interface{}, msg string
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Error(err error, msgAndArgs ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return Error(a.t, err, msgAndArgs...)
 }
 
@@ -154,6 +206,10 @@ func (a *Assertions) Error(err error, msgAndArgs ...interface{}) bool {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Errorf(err error, msg string, args ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return Errorf(a.t, err, msg, args...)
 }
 
@@ -163,6 +219,10 @@ func (a *Assertions) Errorf(err error, msg string, args ...interface{}) bool {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Exactly(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return Exactly(a.t, expected, actual, msgAndArgs...)
 }
 
@@ -172,26 +232,46 @@ func (a *Assertions) Exactly(expected interface{}, actual interface{}, msgAndArg
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Exactlyf(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return Exactlyf(a.t, expected, actual, msg, args...)
 }
 
 // Fail reports a failure through
 func (a *Assertions) Fail(failureMessage string, msgAndArgs ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return Fail(a.t, failureMessage, msgAndArgs...)
 }
 
 // FailNow fails test
 func (a *Assertions) FailNow(failureMessage string, msgAndArgs ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return FailNow(a.t, failureMessage, msgAndArgs...)
 }
 
 // FailNowf fails test
 func (a *Assertions) FailNowf(failureMessage string, msg string, args ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return FailNowf(a.t, failureMessage, msg, args...)
 }
 
 // Failf reports a failure through
 func (a *Assertions) Failf(failureMessage string, msg string, args ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return Failf(a.t, failureMessage, msg, args...)
 }
 
@@ -201,6 +281,10 @@ func (a *Assertions) Failf(failureMessage string, msg string, args ...interface{
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) False(value bool, msgAndArgs ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return False(a.t, value, msgAndArgs...)
 }
 
@@ -210,6 +294,10 @@ func (a *Assertions) False(value bool, msgAndArgs ...interface{}) bool {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Falsef(value bool, msg string, args ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return Falsef(a.t, value, msg, args...)
 }
 
@@ -220,6 +308,10 @@ func (a *Assertions) Falsef(value bool, msg string, args ...interface{}) bool {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPBodyContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return HTTPBodyContains(a.t, handler, method, url, values, str)
 }
 
@@ -230,6 +322,10 @@ func (a *Assertions) HTTPBodyContains(handler http.HandlerFunc, method string, u
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPBodyContainsf(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return HTTPBodyContainsf(a.t, handler, method, url, values, str)
 }
 
@@ -240,6 +336,10 @@ func (a *Assertions) HTTPBodyContainsf(handler http.HandlerFunc, method string, 
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPBodyNotContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return HTTPBodyNotContains(a.t, handler, method, url, values, str)
 }
 
@@ -250,6 +350,10 @@ func (a *Assertions) HTTPBodyNotContains(handler http.HandlerFunc, method string
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPBodyNotContainsf(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return HTTPBodyNotContainsf(a.t, handler, method, url, values, str)
 }
 
@@ -259,6 +363,10 @@ func (a *Assertions) HTTPBodyNotContainsf(handler http.HandlerFunc, method strin
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPError(handler http.HandlerFunc, method string, url string, values url.Values) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return HTTPError(a.t, handler, method, url, values)
 }
 
@@ -268,6 +376,10 @@ func (a *Assertions) HTTPError(handler http.HandlerFunc, method string, url stri
 //
 // Returns whether the assertion was successful (true, "error message %s", "formatted") or not (false).
 func (a *Assertions) HTTPErrorf(handler http.HandlerFunc, method string, url string, values url.Values) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return HTTPErrorf(a.t, handler, method, url, values)
 }
 
@@ -277,6 +389,10 @@ func (a *Assertions) HTTPErrorf(handler http.HandlerFunc, method string, url str
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPRedirect(handler http.HandlerFunc, method string, url string, values url.Values) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return HTTPRedirect(a.t, handler, method, url, values)
 }
 
@@ -286,6 +402,10 @@ func (a *Assertions) HTTPRedirect(handler http.HandlerFunc, method string, url s
 //
 // Returns whether the assertion was successful (true, "error message %s", "formatted") or not (false).
 func (a *Assertions) HTTPRedirectf(handler http.HandlerFunc, method string, url string, values url.Values) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return HTTPRedirectf(a.t, handler, method, url, values)
 }
 
@@ -295,6 +415,10 @@ func (a *Assertions) HTTPRedirectf(handler http.HandlerFunc, method string, url 
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPSuccess(handler http.HandlerFunc, method string, url string, values url.Values) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return HTTPSuccess(a.t, handler, method, url, values)
 }
 
@@ -304,6 +428,10 @@ func (a *Assertions) HTTPSuccess(handler http.HandlerFunc, method string, url st
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPSuccessf(handler http.HandlerFunc, method string, url string, values url.Values) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return HTTPSuccessf(a.t, handler, method, url, values)
 }
 
@@ -311,6 +439,10 @@ func (a *Assertions) HTTPSuccessf(handler http.HandlerFunc, method string, url s
 //
 //    a.Implements((*MyInterface)(nil), new(MyObject))
 func (a *Assertions) Implements(interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return Implements(a.t, interfaceObject, object, msgAndArgs...)
 }
 
@@ -318,6 +450,10 @@ func (a *Assertions) Implements(interfaceObject interface{}, object interface{},
 //
 //    a.Implementsf((*MyInterface, "error message %s", "formatted")(nil), new(MyObject))
 func (a *Assertions) Implementsf(interfaceObject interface{}, object interface{}, msg string, args ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return Implementsf(a.t, interfaceObject, object, msg, args...)
 }
 
@@ -327,16 +463,28 @@ func (a *Assertions) Implementsf(interfaceObject interface{}, object interface{}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) InDelta(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return InDelta(a.t, expected, actual, delta, msgAndArgs...)
 }
 
 // InDeltaSlice is the same as InDelta, except it compares two slices.
 func (a *Assertions) InDeltaSlice(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return InDeltaSlice(a.t, expected, actual, delta, msgAndArgs...)
 }
 
 // InDeltaSlicef is the same as InDelta, except it compares two slices.
 func (a *Assertions) InDeltaSlicef(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return InDeltaSlicef(a.t, expected, actual, delta, msg, args...)
 }
 
@@ -346,6 +494,10 @@ func (a *Assertions) InDeltaSlicef(expected interface{}, actual interface{}, del
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) InDeltaf(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return InDeltaf(a.t, expected, actual, delta, msg, args...)
 }
 
@@ -353,16 +505,28 @@ func (a *Assertions) InDeltaf(expected interface{}, actual interface{}, delta fl
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) InEpsilon(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return InEpsilon(a.t, expected, actual, epsilon, msgAndArgs...)
 }
 
 // InEpsilonSlice is the same as InEpsilon, except it compares each value from two slices.
 func (a *Assertions) InEpsilonSlice(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return InEpsilonSlice(a.t, expected, actual, epsilon, msgAndArgs...)
 }
 
 // InEpsilonSlicef is the same as InEpsilon, except it compares each value from two slices.
 func (a *Assertions) InEpsilonSlicef(expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return InEpsilonSlicef(a.t, expected, actual, epsilon, msg, args...)
 }
 
@@ -370,16 +534,28 @@ func (a *Assertions) InEpsilonSlicef(expected interface{}, actual interface{}, e
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) InEpsilonf(expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return InEpsilonf(a.t, expected, actual, epsilon, msg, args...)
 }
 
 // IsType asserts that the specified objects are of the same type.
 func (a *Assertions) IsType(expectedType interface{}, object interface{}, msgAndArgs ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return IsType(a.t, expectedType, object, msgAndArgs...)
 }
 
 // IsTypef asserts that the specified objects are of the same type.
 func (a *Assertions) IsTypef(expectedType interface{}, object interface{}, msg string, args ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return IsTypef(a.t, expectedType, object, msg, args...)
 }
 
@@ -389,6 +565,10 @@ func (a *Assertions) IsTypef(expectedType interface{}, object interface{}, msg s
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) JSONEq(expected string, actual string, msgAndArgs ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return JSONEq(a.t, expected, actual, msgAndArgs...)
 }
 
@@ -398,6 +578,10 @@ func (a *Assertions) JSONEq(expected string, actual string, msgAndArgs ...interf
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) JSONEqf(expected string, actual string, msg string, args ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return JSONEqf(a.t, expected, actual, msg, args...)
 }
 
@@ -408,6 +592,10 @@ func (a *Assertions) JSONEqf(expected string, actual string, msg string, args ..
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return Len(a.t, object, length, msgAndArgs...)
 }
 
@@ -418,6 +606,10 @@ func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Lenf(object interface{}, length int, msg string, args ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return Lenf(a.t, object, length, msg, args...)
 }
 
@@ -427,6 +619,10 @@ func (a *Assertions) Lenf(object interface{}, length int, msg string, args ...in
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Nil(object interface{}, msgAndArgs ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return Nil(a.t, object, msgAndArgs...)
 }
 
@@ -436,6 +632,10 @@ func (a *Assertions) Nil(object interface{}, msgAndArgs ...interface{}) bool {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Nilf(object interface{}, msg string, args ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return Nilf(a.t, object, msg, args...)
 }
 
@@ -448,6 +648,10 @@ func (a *Assertions) Nilf(object interface{}, msg string, args ...interface{}) b
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NoError(err error, msgAndArgs ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return NoError(a.t, err, msgAndArgs...)
 }
 
@@ -460,6 +664,10 @@ func (a *Assertions) NoError(err error, msgAndArgs ...interface{}) bool {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NoErrorf(err error, msg string, args ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return NoErrorf(a.t, err, msg, args...)
 }
 
@@ -472,6 +680,10 @@ func (a *Assertions) NoErrorf(err error, msg string, args ...interface{}) bool {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotContains(s interface{}, contains interface{}, msgAndArgs ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return NotContains(a.t, s, contains, msgAndArgs...)
 }
 
@@ -484,6 +696,10 @@ func (a *Assertions) NotContains(s interface{}, contains interface{}, msgAndArgs
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotContainsf(s interface{}, contains interface{}, msg string, args ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return NotContainsf(a.t, s, contains, msg, args...)
 }
 
@@ -496,6 +712,10 @@ func (a *Assertions) NotContainsf(s interface{}, contains interface{}, msg strin
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return NotEmpty(a.t, object, msgAndArgs...)
 }
 
@@ -508,6 +728,10 @@ func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) boo
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotEmptyf(object interface{}, msg string, args ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return NotEmptyf(a.t, object, msg, args...)
 }
 
@@ -520,6 +744,10 @@ func (a *Assertions) NotEmptyf(object interface{}, msg string, args ...interface
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
 func (a *Assertions) NotEqual(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return NotEqual(a.t, expected, actual, msgAndArgs...)
 }
 
@@ -532,6 +760,10 @@ func (a *Assertions) NotEqual(expected interface{}, actual interface{}, msgAndAr
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
 func (a *Assertions) NotEqualf(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return NotEqualf(a.t, expected, actual, msg, args...)
 }
 
@@ -541,6 +773,10 @@ func (a *Assertions) NotEqualf(expected interface{}, actual interface{}, msg str
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotNil(object interface{}, msgAndArgs ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return NotNil(a.t, object, msgAndArgs...)
 }
 
@@ -550,6 +786,10 @@ func (a *Assertions) NotNil(object interface{}, msgAndArgs ...interface{}) bool 
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotNilf(object interface{}, msg string, args ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return NotNilf(a.t, object, msg, args...)
 }
 
@@ -559,6 +799,10 @@ func (a *Assertions) NotNilf(object interface{}, msg string, args ...interface{}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotPanics(f PanicTestFunc, msgAndArgs ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return NotPanics(a.t, f, msgAndArgs...)
 }
 
@@ -568,6 +812,10 @@ func (a *Assertions) NotPanics(f PanicTestFunc, msgAndArgs ...interface{}) bool 
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotPanicsf(f PanicTestFunc, msg string, args ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return NotPanicsf(a.t, f, msg, args...)
 }
 
@@ -578,6 +826,10 @@ func (a *Assertions) NotPanicsf(f PanicTestFunc, msg string, args ...interface{}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return NotRegexp(a.t, rx, str, msgAndArgs...)
 }
 
@@ -588,6 +840,10 @@ func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...in
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotRegexpf(rx interface{}, str interface{}, msg string, args ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return NotRegexpf(a.t, rx, str, msg, args...)
 }
 
@@ -598,6 +854,10 @@ func (a *Assertions) NotRegexpf(rx interface{}, str interface{}, msg string, arg
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotSubset(list interface{}, subset interface{}, msgAndArgs ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return NotSubset(a.t, list, subset, msgAndArgs...)
 }
 
@@ -608,16 +868,28 @@ func (a *Assertions) NotSubset(list interface{}, subset interface{}, msgAndArgs 
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotSubsetf(list interface{}, subset interface{}, msg string, args ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return NotSubsetf(a.t, list, subset, msg, args...)
 }
 
 // NotZero asserts that i is not the zero value for its type and returns the truth.
 func (a *Assertions) NotZero(i interface{}, msgAndArgs ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return NotZero(a.t, i, msgAndArgs...)
 }
 
 // NotZerof asserts that i is not the zero value for its type and returns the truth.
 func (a *Assertions) NotZerof(i interface{}, msg string, args ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return NotZerof(a.t, i, msg, args...)
 }
 
@@ -627,6 +899,10 @@ func (a *Assertions) NotZerof(i interface{}, msg string, args ...interface{}) bo
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Panics(f PanicTestFunc, msgAndArgs ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return Panics(a.t, f, msgAndArgs...)
 }
 
@@ -637,6 +913,10 @@ func (a *Assertions) Panics(f PanicTestFunc, msgAndArgs ...interface{}) bool {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) PanicsWithValue(expected interface{}, f PanicTestFunc, msgAndArgs ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return PanicsWithValue(a.t, expected, f, msgAndArgs...)
 }
 
@@ -647,6 +927,10 @@ func (a *Assertions) PanicsWithValue(expected interface{}, f PanicTestFunc, msgA
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) PanicsWithValuef(expected interface{}, f PanicTestFunc, msg string, args ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return PanicsWithValuef(a.t, expected, f, msg, args...)
 }
 
@@ -656,6 +940,10 @@ func (a *Assertions) PanicsWithValuef(expected interface{}, f PanicTestFunc, msg
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Panicsf(f PanicTestFunc, msg string, args ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return Panicsf(a.t, f, msg, args...)
 }
 
@@ -666,6 +954,10 @@ func (a *Assertions) Panicsf(f PanicTestFunc, msg string, args ...interface{}) b
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return Regexp(a.t, rx, str, msgAndArgs...)
 }
 
@@ -676,6 +968,10 @@ func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...inter
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Regexpf(rx interface{}, str interface{}, msg string, args ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return Regexpf(a.t, rx, str, msg, args...)
 }
 
@@ -686,6 +982,10 @@ func (a *Assertions) Regexpf(rx interface{}, str interface{}, msg string, args .
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Subset(list interface{}, subset interface{}, msgAndArgs ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return Subset(a.t, list, subset, msgAndArgs...)
 }
 
@@ -696,6 +996,10 @@ func (a *Assertions) Subset(list interface{}, subset interface{}, msgAndArgs ...
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Subsetf(list interface{}, subset interface{}, msg string, args ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return Subsetf(a.t, list, subset, msg, args...)
 }
 
@@ -705,6 +1009,10 @@ func (a *Assertions) Subsetf(list interface{}, subset interface{}, msg string, a
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) True(value bool, msgAndArgs ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return True(a.t, value, msgAndArgs...)
 }
 
@@ -714,6 +1022,10 @@ func (a *Assertions) True(value bool, msgAndArgs ...interface{}) bool {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Truef(value bool, msg string, args ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return Truef(a.t, value, msg, args...)
 }
 
@@ -723,6 +1035,10 @@ func (a *Assertions) Truef(value bool, msg string, args ...interface{}) bool {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) WithinDuration(expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return WithinDuration(a.t, expected, actual, delta, msgAndArgs...)
 }
 
@@ -732,15 +1048,27 @@ func (a *Assertions) WithinDuration(expected time.Time, actual time.Time, delta 
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) WithinDurationf(expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return WithinDurationf(a.t, expected, actual, delta, msg, args...)
 }
 
 // Zero asserts that i is the zero value for its type and returns the truth.
 func (a *Assertions) Zero(i interface{}, msgAndArgs ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return Zero(a.t, i, msgAndArgs...)
 }
 
 // Zerof asserts that i is the zero value for its type and returns the truth.
 func (a *Assertions) Zerof(i interface{}, msg string, args ...interface{}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return Zerof(a.t, i, msg, args...)
 }

--- a/assert/assertion_forward.go.tmpl
+++ b/assert/assertion_forward.go.tmpl
@@ -1,4 +1,8 @@
 {{.CommentWithoutT "a"}}
 func (a *Assertions) {{.DocInfo.Name}}({{.Params}}) bool {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	return {{.DocInfo.Name}}(a.t, {{.ForwardedParams}})
 }

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -26,6 +26,10 @@ type TestingT interface {
 	Errorf(format string, args ...interface{})
 }
 
+type helper interface {
+	Helper()
+}
+
 // Comparison a custom function that returns true on success and false on failure
 type Comparison func() (success bool)
 
@@ -208,6 +212,10 @@ type failNower interface {
 
 // FailNow fails test
 func FailNow(t TestingT, failureMessage string, msgAndArgs ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	Fail(t, failureMessage, msgAndArgs...)
 
 	// We cannot extend TestingT with FailNow() and
@@ -226,10 +234,14 @@ func FailNow(t TestingT, failureMessage string, msgAndArgs ...interface{}) bool 
 
 // Fail reports a failure through
 func Fail(t TestingT, failureMessage string, msgAndArgs ...interface{}) bool {
-	content := []labeledContent{
-		{"Error Trace", strings.Join(CallerInfo(), "\n\r\t\t\t")},
-		{"Error", failureMessage},
+	var content []labeledContent
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	} else {
+		content = append(content, labeledContent{"Error Trace", strings.Join(CallerInfo(), "\n\r\t\t\t")})
 	}
+
+	content = append(content, labeledContent{"Error", failureMessage})
 
 	message := messageFromMsgAndArgs(msgAndArgs...)
 	if len(message) > 0 {
@@ -273,6 +285,9 @@ func labeledOutput(content ...labeledContent) string {
 //
 //    assert.Implements(t, (*MyInterface)(nil), new(MyObject))
 func Implements(t TestingT, interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
 
 	interfaceType := reflect.TypeOf(interfaceObject).Elem()
 
@@ -286,6 +301,9 @@ func Implements(t TestingT, interfaceObject interface{}, object interface{}, msg
 
 // IsType asserts that the specified objects are of the same type.
 func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
 
 	if !ObjectsAreEqual(reflect.TypeOf(object), reflect.TypeOf(expectedType)) {
 		return Fail(t, fmt.Sprintf("Object expected to be of type %v, but was %v", reflect.TypeOf(expectedType), reflect.TypeOf(object)), msgAndArgs...)
@@ -304,6 +322,10 @@ func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs
 // referenced values (as opposed to the memory addresses). Function equality
 // cannot be determined and will always fail.
 func Equal(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if err := validateEqualArgs(expected, actual); err != nil {
 		return Fail(t, fmt.Sprintf("Invalid operation: %#v == %#v (%s)",
 			expected, actual, err), msgAndArgs...)
@@ -344,6 +366,9 @@ func formatUnequalValues(expected, actual interface{}) (e string, a string) {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func EqualValues(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
 
 	if !ObjectsAreEqualValues(expected, actual) {
 		diff := diff(expected, actual)
@@ -363,6 +388,9 @@ func EqualValues(t TestingT, expected, actual interface{}, msgAndArgs ...interfa
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Exactly(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
 
 	aType := reflect.TypeOf(expected)
 	bType := reflect.TypeOf(actual)
@@ -381,6 +409,10 @@ func Exactly(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !isNil(object) {
 		return true
 	}
@@ -408,6 +440,10 @@ func isNil(object interface{}) bool {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if isNil(object) {
 		return true
 	}
@@ -481,6 +517,9 @@ func isEmpty(object interface{}) bool {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
 
 	pass := isEmpty(object)
 	if !pass {
@@ -500,6 +539,9 @@ func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
 
 	pass := !isEmpty(object)
 	if !pass {
@@ -529,6 +571,10 @@ func getLen(x interface{}) (ok bool, length int) {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	ok, l := getLen(object)
 	if !ok {
 		return Fail(t, fmt.Sprintf("\"%s\" could not be applied builtin len()", object), msgAndArgs...)
@@ -546,6 +592,9 @@ func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) 
 //
 // Returns whether the assertion was successful (true) or not (false).
 func True(t TestingT, value bool, msgAndArgs ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
 
 	if value != true {
 		return Fail(t, "Should be true", msgAndArgs...)
@@ -561,6 +610,9 @@ func True(t TestingT, value bool, msgAndArgs ...interface{}) bool {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func False(t TestingT, value bool, msgAndArgs ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
 
 	if value != false {
 		return Fail(t, "Should be false", msgAndArgs...)
@@ -639,6 +691,9 @@ func includeElement(list interface{}, element interface{}) (ok, found bool) {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Contains(t TestingT, s, contains interface{}, msgAndArgs ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
 
 	ok, found := includeElement(s, contains)
 	if !ok {
@@ -661,6 +716,9 @@ func Contains(t TestingT, s, contains interface{}, msgAndArgs ...interface{}) bo
 //
 // Returns whether the assertion was successful (true) or not (false).
 func NotContains(t TestingT, s, contains interface{}, msgAndArgs ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
 
 	ok, found := includeElement(s, contains)
 	if !ok {
@@ -681,6 +739,10 @@ func NotContains(t TestingT, s, contains interface{}, msgAndArgs ...interface{})
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Subset(t TestingT, list, subset interface{}, msgAndArgs ...interface{}) (ok bool) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if subset == nil {
 		return true // we consider nil to be equal to the nil set
 	}
@@ -724,6 +786,10 @@ func Subset(t TestingT, list, subset interface{}, msgAndArgs ...interface{}) (ok
 //
 // Returns whether the assertion was successful (true) or not (false).
 func NotSubset(t TestingT, list, subset interface{}, msgAndArgs ...interface{}) (ok bool) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if subset == nil {
 		return false // we consider nil to be equal to the nil set
 	}
@@ -762,6 +828,10 @@ func NotSubset(t TestingT, list, subset interface{}, msgAndArgs ...interface{}) 
 
 // Condition uses a Comparison to assert a complex condition.
 func Condition(t TestingT, comp Comparison, msgAndArgs ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	result := comp()
 	if !result {
 		Fail(t, "Condition failed!", msgAndArgs...)
@@ -801,6 +871,9 @@ func didPanic(f PanicTestFunc) (bool, interface{}) {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Panics(t TestingT, f PanicTestFunc, msgAndArgs ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
 
 	if funcDidPanic, panicValue := didPanic(f); !funcDidPanic {
 		return Fail(t, fmt.Sprintf("func %#v should panic\n\r\tPanic value:\t%v", f, panicValue), msgAndArgs...)
@@ -816,6 +889,9 @@ func Panics(t TestingT, f PanicTestFunc, msgAndArgs ...interface{}) bool {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func PanicsWithValue(t TestingT, expected interface{}, f PanicTestFunc, msgAndArgs ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
 
 	funcDidPanic, panicValue := didPanic(f)
 	if !funcDidPanic {
@@ -834,6 +910,9 @@ func PanicsWithValue(t TestingT, expected interface{}, f PanicTestFunc, msgAndAr
 //
 // Returns whether the assertion was successful (true) or not (false).
 func NotPanics(t TestingT, f PanicTestFunc, msgAndArgs ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
 
 	if funcDidPanic, panicValue := didPanic(f); funcDidPanic {
 		return Fail(t, fmt.Sprintf("func %#v should not panic\n\r\tPanic value:\t%v", f, panicValue), msgAndArgs...)
@@ -848,6 +927,9 @@ func NotPanics(t TestingT, f PanicTestFunc, msgAndArgs ...interface{}) bool {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func WithinDuration(t TestingT, expected, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
 
 	dt := expected.Sub(actual)
 	if dt < -delta || dt > delta {
@@ -899,6 +981,9 @@ func toFloat(x interface{}) (float64, bool) {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func InDelta(t TestingT, expected, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
 
 	af, aok := toFloat(expected)
 	bf, bok := toFloat(actual)
@@ -925,6 +1010,10 @@ func InDelta(t TestingT, expected, actual interface{}, delta float64, msgAndArgs
 
 // InDeltaSlice is the same as InDelta, except it compares two slices.
 func InDeltaSlice(t TestingT, expected, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if expected == nil || actual == nil ||
 		reflect.TypeOf(actual).Kind() != reflect.Slice ||
 		reflect.TypeOf(expected).Kind() != reflect.Slice {
@@ -964,6 +1053,10 @@ func calcRelativeError(expected, actual interface{}) (float64, error) {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func InEpsilon(t TestingT, expected, actual interface{}, epsilon float64, msgAndArgs ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	actualEpsilon, err := calcRelativeError(expected, actual)
 	if err != nil {
 		return Fail(t, err.Error(), msgAndArgs...)
@@ -978,6 +1071,10 @@ func InEpsilon(t TestingT, expected, actual interface{}, epsilon float64, msgAnd
 
 // InEpsilonSlice is the same as InEpsilon, except it compares each value from two slices.
 func InEpsilonSlice(t TestingT, expected, actual interface{}, epsilon float64, msgAndArgs ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if expected == nil || actual == nil ||
 		reflect.TypeOf(actual).Kind() != reflect.Slice ||
 		reflect.TypeOf(expected).Kind() != reflect.Slice {
@@ -1010,6 +1107,10 @@ func InEpsilonSlice(t TestingT, expected, actual interface{}, epsilon float64, m
 //
 // Returns whether the assertion was successful (true) or not (false).
 func NoError(t TestingT, err error, msgAndArgs ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if err != nil {
 		return Fail(t, fmt.Sprintf("Received unexpected error:\n%+v", err), msgAndArgs...)
 	}
@@ -1026,6 +1127,9 @@ func NoError(t TestingT, err error, msgAndArgs ...interface{}) bool {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Error(t TestingT, err error, msgAndArgs ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
 
 	if err == nil {
 		return Fail(t, "An error is expected but got nil.", msgAndArgs...)
@@ -1042,6 +1146,10 @@ func Error(t TestingT, err error, msgAndArgs ...interface{}) bool {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func EqualError(t TestingT, theError error, errString string, msgAndArgs ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !Error(t, theError, msgAndArgs...) {
 		return false
 	}
@@ -1077,6 +1185,9 @@ func matchRegexp(rx interface{}, str interface{}) bool {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
 
 	match := matchRegexp(rx, str)
 
@@ -1094,6 +1205,10 @@ func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface
 //
 // Returns whether the assertion was successful (true) or not (false).
 func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	match := matchRegexp(rx, str)
 
 	if match {
@@ -1106,6 +1221,10 @@ func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interf
 
 // Zero asserts that i is the zero value for its type and returns the truth.
 func Zero(t TestingT, i interface{}, msgAndArgs ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if i != nil && !reflect.DeepEqual(i, reflect.Zero(reflect.TypeOf(i)).Interface()) {
 		return Fail(t, fmt.Sprintf("Should be zero, but was %v", i), msgAndArgs...)
 	}
@@ -1114,6 +1233,10 @@ func Zero(t TestingT, i interface{}, msgAndArgs ...interface{}) bool {
 
 // NotZero asserts that i is not the zero value for its type and returns the truth.
 func NotZero(t TestingT, i interface{}, msgAndArgs ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if i == nil || reflect.DeepEqual(i, reflect.Zero(reflect.TypeOf(i)).Interface()) {
 		return Fail(t, fmt.Sprintf("Should not be zero, but was %v", i), msgAndArgs...)
 	}
@@ -1126,6 +1249,10 @@ func NotZero(t TestingT, i interface{}, msgAndArgs ...interface{}) bool {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) bool {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	var expectedJSONAsInterface, actualJSONAsInterface interface{}
 
 	if err := json.Unmarshal([]byte(expected), &expectedJSONAsInterface); err != nil {

--- a/require/require.go
+++ b/require/require.go
@@ -14,6 +14,10 @@ import (
 
 // Condition uses a Comparison to assert a complex condition.
 func Condition(t TestingT, comp assert.Comparison, msgAndArgs ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.Condition(t, comp, msgAndArgs...) {
 		t.FailNow()
 	}
@@ -21,6 +25,10 @@ func Condition(t TestingT, comp assert.Comparison, msgAndArgs ...interface{}) {
 
 // Conditionf uses a Comparison to assert a complex condition.
 func Conditionf(t TestingT, comp assert.Comparison, msg string, args ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.Conditionf(t, comp, msg, args...) {
 		t.FailNow()
 	}
@@ -35,6 +43,10 @@ func Conditionf(t TestingT, comp assert.Comparison, msg string, args ...interfac
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Contains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.Contains(t, s, contains, msgAndArgs...) {
 		t.FailNow()
 	}
@@ -49,6 +61,10 @@ func Contains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...int
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Containsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.Containsf(t, s, contains, msg, args...) {
 		t.FailNow()
 	}
@@ -61,6 +77,10 @@ func Containsf(t TestingT, s interface{}, contains interface{}, msg string, args
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.Empty(t, object, msgAndArgs...) {
 		t.FailNow()
 	}
@@ -73,6 +93,10 @@ func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.Emptyf(t, object, msg, args...) {
 		t.FailNow()
 	}
@@ -88,6 +112,10 @@ func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
 // referenced values (as opposed to the memory addresses). Function equality
 // cannot be determined and will always fail.
 func Equal(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.Equal(t, expected, actual, msgAndArgs...) {
 		t.FailNow()
 	}
@@ -101,6 +129,10 @@ func Equal(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...i
 //
 // Returns whether the assertion was successful (true) or not (false).
 func EqualError(t TestingT, theError error, errString string, msgAndArgs ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.EqualError(t, theError, errString, msgAndArgs...) {
 		t.FailNow()
 	}
@@ -114,6 +146,10 @@ func EqualError(t TestingT, theError error, errString string, msgAndArgs ...inte
 //
 // Returns whether the assertion was successful (true) or not (false).
 func EqualErrorf(t TestingT, theError error, errString string, msg string, args ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.EqualErrorf(t, theError, errString, msg, args...) {
 		t.FailNow()
 	}
@@ -126,6 +162,10 @@ func EqualErrorf(t TestingT, theError error, errString string, msg string, args 
 //
 // Returns whether the assertion was successful (true) or not (false).
 func EqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.EqualValues(t, expected, actual, msgAndArgs...) {
 		t.FailNow()
 	}
@@ -138,6 +178,10 @@ func EqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArg
 //
 // Returns whether the assertion was successful (true) or not (false).
 func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.EqualValuesf(t, expected, actual, msg, args...) {
 		t.FailNow()
 	}
@@ -153,6 +197,10 @@ func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg stri
 // referenced values (as opposed to the memory addresses). Function equality
 // cannot be determined and will always fail.
 func Equalf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.Equalf(t, expected, actual, msg, args...) {
 		t.FailNow()
 	}
@@ -167,6 +215,10 @@ func Equalf(t TestingT, expected interface{}, actual interface{}, msg string, ar
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Error(t TestingT, err error, msgAndArgs ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.Error(t, err, msgAndArgs...) {
 		t.FailNow()
 	}
@@ -181,6 +233,10 @@ func Error(t TestingT, err error, msgAndArgs ...interface{}) {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Errorf(t TestingT, err error, msg string, args ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.Errorf(t, err, msg, args...) {
 		t.FailNow()
 	}
@@ -192,6 +248,10 @@ func Errorf(t TestingT, err error, msg string, args ...interface{}) {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Exactly(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.Exactly(t, expected, actual, msgAndArgs...) {
 		t.FailNow()
 	}
@@ -203,6 +263,10 @@ func Exactly(t TestingT, expected interface{}, actual interface{}, msgAndArgs ..
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Exactlyf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.Exactlyf(t, expected, actual, msg, args...) {
 		t.FailNow()
 	}
@@ -210,6 +274,10 @@ func Exactlyf(t TestingT, expected interface{}, actual interface{}, msg string, 
 
 // Fail reports a failure through
 func Fail(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.Fail(t, failureMessage, msgAndArgs...) {
 		t.FailNow()
 	}
@@ -217,6 +285,10 @@ func Fail(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
 
 // FailNow fails test
 func FailNow(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.FailNow(t, failureMessage, msgAndArgs...) {
 		t.FailNow()
 	}
@@ -224,6 +296,10 @@ func FailNow(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
 
 // FailNowf fails test
 func FailNowf(t TestingT, failureMessage string, msg string, args ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.FailNowf(t, failureMessage, msg, args...) {
 		t.FailNow()
 	}
@@ -231,6 +307,10 @@ func FailNowf(t TestingT, failureMessage string, msg string, args ...interface{}
 
 // Failf reports a failure through
 func Failf(t TestingT, failureMessage string, msg string, args ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.Failf(t, failureMessage, msg, args...) {
 		t.FailNow()
 	}
@@ -242,6 +322,10 @@ func Failf(t TestingT, failureMessage string, msg string, args ...interface{}) {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func False(t TestingT, value bool, msgAndArgs ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.False(t, value, msgAndArgs...) {
 		t.FailNow()
 	}
@@ -253,6 +337,10 @@ func False(t TestingT, value bool, msgAndArgs ...interface{}) {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Falsef(t TestingT, value bool, msg string, args ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.Falsef(t, value, msg, args...) {
 		t.FailNow()
 	}
@@ -265,6 +353,10 @@ func Falsef(t TestingT, value bool, msg string, args ...interface{}) {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPBodyContains(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.HTTPBodyContains(t, handler, method, url, values, str) {
 		t.FailNow()
 	}
@@ -277,6 +369,10 @@ func HTTPBodyContains(t TestingT, handler http.HandlerFunc, method string, url s
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPBodyContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.HTTPBodyContainsf(t, handler, method, url, values, str) {
 		t.FailNow()
 	}
@@ -289,6 +385,10 @@ func HTTPBodyContainsf(t TestingT, handler http.HandlerFunc, method string, url 
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPBodyNotContains(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.HTTPBodyNotContains(t, handler, method, url, values, str) {
 		t.FailNow()
 	}
@@ -301,6 +401,10 @@ func HTTPBodyNotContains(t TestingT, handler http.HandlerFunc, method string, ur
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPBodyNotContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.HTTPBodyNotContainsf(t, handler, method, url, values, str) {
 		t.FailNow()
 	}
@@ -312,6 +416,10 @@ func HTTPBodyNotContainsf(t TestingT, handler http.HandlerFunc, method string, u
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPError(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.HTTPError(t, handler, method, url, values) {
 		t.FailNow()
 	}
@@ -323,6 +431,10 @@ func HTTPError(t TestingT, handler http.HandlerFunc, method string, url string, 
 //
 // Returns whether the assertion was successful (true, "error message %s", "formatted") or not (false).
 func HTTPErrorf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.HTTPErrorf(t, handler, method, url, values) {
 		t.FailNow()
 	}
@@ -334,6 +446,10 @@ func HTTPErrorf(t TestingT, handler http.HandlerFunc, method string, url string,
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPRedirect(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.HTTPRedirect(t, handler, method, url, values) {
 		t.FailNow()
 	}
@@ -345,6 +461,10 @@ func HTTPRedirect(t TestingT, handler http.HandlerFunc, method string, url strin
 //
 // Returns whether the assertion was successful (true, "error message %s", "formatted") or not (false).
 func HTTPRedirectf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.HTTPRedirectf(t, handler, method, url, values) {
 		t.FailNow()
 	}
@@ -356,6 +476,10 @@ func HTTPRedirectf(t TestingT, handler http.HandlerFunc, method string, url stri
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPSuccess(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.HTTPSuccess(t, handler, method, url, values) {
 		t.FailNow()
 	}
@@ -367,6 +491,10 @@ func HTTPSuccess(t TestingT, handler http.HandlerFunc, method string, url string
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPSuccessf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.HTTPSuccessf(t, handler, method, url, values) {
 		t.FailNow()
 	}
@@ -376,6 +504,10 @@ func HTTPSuccessf(t TestingT, handler http.HandlerFunc, method string, url strin
 //
 //    assert.Implements(t, (*MyInterface)(nil), new(MyObject))
 func Implements(t TestingT, interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.Implements(t, interfaceObject, object, msgAndArgs...) {
 		t.FailNow()
 	}
@@ -385,6 +517,10 @@ func Implements(t TestingT, interfaceObject interface{}, object interface{}, msg
 //
 //    assert.Implementsf(t, (*MyInterface, "error message %s", "formatted")(nil), new(MyObject))
 func Implementsf(t TestingT, interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.Implementsf(t, interfaceObject, object, msg, args...) {
 		t.FailNow()
 	}
@@ -396,6 +532,10 @@ func Implementsf(t TestingT, interfaceObject interface{}, object interface{}, ms
 //
 // Returns whether the assertion was successful (true) or not (false).
 func InDelta(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.InDelta(t, expected, actual, delta, msgAndArgs...) {
 		t.FailNow()
 	}
@@ -403,6 +543,10 @@ func InDelta(t TestingT, expected interface{}, actual interface{}, delta float64
 
 // InDeltaSlice is the same as InDelta, except it compares two slices.
 func InDeltaSlice(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.InDeltaSlice(t, expected, actual, delta, msgAndArgs...) {
 		t.FailNow()
 	}
@@ -410,6 +554,10 @@ func InDeltaSlice(t TestingT, expected interface{}, actual interface{}, delta fl
 
 // InDeltaSlicef is the same as InDelta, except it compares two slices.
 func InDeltaSlicef(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.InDeltaSlicef(t, expected, actual, delta, msg, args...) {
 		t.FailNow()
 	}
@@ -421,6 +569,10 @@ func InDeltaSlicef(t TestingT, expected interface{}, actual interface{}, delta f
 //
 // Returns whether the assertion was successful (true) or not (false).
 func InDeltaf(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.InDeltaf(t, expected, actual, delta, msg, args...) {
 		t.FailNow()
 	}
@@ -430,6 +582,10 @@ func InDeltaf(t TestingT, expected interface{}, actual interface{}, delta float6
 //
 // Returns whether the assertion was successful (true) or not (false).
 func InEpsilon(t TestingT, expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.InEpsilon(t, expected, actual, epsilon, msgAndArgs...) {
 		t.FailNow()
 	}
@@ -437,6 +593,10 @@ func InEpsilon(t TestingT, expected interface{}, actual interface{}, epsilon flo
 
 // InEpsilonSlice is the same as InEpsilon, except it compares each value from two slices.
 func InEpsilonSlice(t TestingT, expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.InEpsilonSlice(t, expected, actual, epsilon, msgAndArgs...) {
 		t.FailNow()
 	}
@@ -444,6 +604,10 @@ func InEpsilonSlice(t TestingT, expected interface{}, actual interface{}, epsilo
 
 // InEpsilonSlicef is the same as InEpsilon, except it compares each value from two slices.
 func InEpsilonSlicef(t TestingT, expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.InEpsilonSlicef(t, expected, actual, epsilon, msg, args...) {
 		t.FailNow()
 	}
@@ -453,6 +617,10 @@ func InEpsilonSlicef(t TestingT, expected interface{}, actual interface{}, epsil
 //
 // Returns whether the assertion was successful (true) or not (false).
 func InEpsilonf(t TestingT, expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.InEpsilonf(t, expected, actual, epsilon, msg, args...) {
 		t.FailNow()
 	}
@@ -460,6 +628,10 @@ func InEpsilonf(t TestingT, expected interface{}, actual interface{}, epsilon fl
 
 // IsType asserts that the specified objects are of the same type.
 func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.IsType(t, expectedType, object, msgAndArgs...) {
 		t.FailNow()
 	}
@@ -467,6 +639,10 @@ func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs
 
 // IsTypef asserts that the specified objects are of the same type.
 func IsTypef(t TestingT, expectedType interface{}, object interface{}, msg string, args ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.IsTypef(t, expectedType, object, msg, args...) {
 		t.FailNow()
 	}
@@ -478,6 +654,10 @@ func IsTypef(t TestingT, expectedType interface{}, object interface{}, msg strin
 //
 // Returns whether the assertion was successful (true) or not (false).
 func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.JSONEq(t, expected, actual, msgAndArgs...) {
 		t.FailNow()
 	}
@@ -489,6 +669,10 @@ func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{
 //
 // Returns whether the assertion was successful (true) or not (false).
 func JSONEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.JSONEqf(t, expected, actual, msg, args...) {
 		t.FailNow()
 	}
@@ -501,6 +685,10 @@ func JSONEqf(t TestingT, expected string, actual string, msg string, args ...int
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.Len(t, object, length, msgAndArgs...) {
 		t.FailNow()
 	}
@@ -513,6 +701,10 @@ func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) 
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Lenf(t TestingT, object interface{}, length int, msg string, args ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.Lenf(t, object, length, msg, args...) {
 		t.FailNow()
 	}
@@ -524,6 +716,10 @@ func Lenf(t TestingT, object interface{}, length int, msg string, args ...interf
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.Nil(t, object, msgAndArgs...) {
 		t.FailNow()
 	}
@@ -535,6 +731,10 @@ func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Nilf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.Nilf(t, object, msg, args...) {
 		t.FailNow()
 	}
@@ -549,6 +749,10 @@ func Nilf(t TestingT, object interface{}, msg string, args ...interface{}) {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func NoError(t TestingT, err error, msgAndArgs ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.NoError(t, err, msgAndArgs...) {
 		t.FailNow()
 	}
@@ -563,6 +767,10 @@ func NoError(t TestingT, err error, msgAndArgs ...interface{}) {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func NoErrorf(t TestingT, err error, msg string, args ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.NoErrorf(t, err, msg, args...) {
 		t.FailNow()
 	}
@@ -577,6 +785,10 @@ func NoErrorf(t TestingT, err error, msg string, args ...interface{}) {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func NotContains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.NotContains(t, s, contains, msgAndArgs...) {
 		t.FailNow()
 	}
@@ -591,6 +803,10 @@ func NotContains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...
 //
 // Returns whether the assertion was successful (true) or not (false).
 func NotContainsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.NotContainsf(t, s, contains, msg, args...) {
 		t.FailNow()
 	}
@@ -605,6 +821,10 @@ func NotContainsf(t TestingT, s interface{}, contains interface{}, msg string, a
 //
 // Returns whether the assertion was successful (true) or not (false).
 func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.NotEmpty(t, object, msgAndArgs...) {
 		t.FailNow()
 	}
@@ -619,6 +839,10 @@ func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func NotEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.NotEmptyf(t, object, msg, args...) {
 		t.FailNow()
 	}
@@ -633,6 +857,10 @@ func NotEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) 
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
 func NotEqual(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.NotEqual(t, expected, actual, msgAndArgs...) {
 		t.FailNow()
 	}
@@ -647,6 +875,10 @@ func NotEqual(t TestingT, expected interface{}, actual interface{}, msgAndArgs .
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
 func NotEqualf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.NotEqualf(t, expected, actual, msg, args...) {
 		t.FailNow()
 	}
@@ -658,6 +890,10 @@ func NotEqualf(t TestingT, expected interface{}, actual interface{}, msg string,
 //
 // Returns whether the assertion was successful (true) or not (false).
 func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.NotNil(t, object, msgAndArgs...) {
 		t.FailNow()
 	}
@@ -669,6 +905,10 @@ func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.NotNilf(t, object, msg, args...) {
 		t.FailNow()
 	}
@@ -680,6 +920,10 @@ func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func NotPanics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.NotPanics(t, f, msgAndArgs...) {
 		t.FailNow()
 	}
@@ -691,6 +935,10 @@ func NotPanics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func NotPanicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.NotPanicsf(t, f, msg, args...) {
 		t.FailNow()
 	}
@@ -703,6 +951,10 @@ func NotPanicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interfac
 //
 // Returns whether the assertion was successful (true) or not (false).
 func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.NotRegexp(t, rx, str, msgAndArgs...) {
 		t.FailNow()
 	}
@@ -715,6 +967,10 @@ func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interf
 //
 // Returns whether the assertion was successful (true) or not (false).
 func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.NotRegexpf(t, rx, str, msg, args...) {
 		t.FailNow()
 	}
@@ -727,6 +983,10 @@ func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ..
 //
 // Returns whether the assertion was successful (true) or not (false).
 func NotSubset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.NotSubset(t, list, subset, msgAndArgs...) {
 		t.FailNow()
 	}
@@ -739,6 +999,10 @@ func NotSubset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...i
 //
 // Returns whether the assertion was successful (true) or not (false).
 func NotSubsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.NotSubsetf(t, list, subset, msg, args...) {
 		t.FailNow()
 	}
@@ -746,6 +1010,10 @@ func NotSubsetf(t TestingT, list interface{}, subset interface{}, msg string, ar
 
 // NotZero asserts that i is not the zero value for its type and returns the truth.
 func NotZero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.NotZero(t, i, msgAndArgs...) {
 		t.FailNow()
 	}
@@ -753,6 +1021,10 @@ func NotZero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
 
 // NotZerof asserts that i is not the zero value for its type and returns the truth.
 func NotZerof(t TestingT, i interface{}, msg string, args ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.NotZerof(t, i, msg, args...) {
 		t.FailNow()
 	}
@@ -764,6 +1036,10 @@ func NotZerof(t TestingT, i interface{}, msg string, args ...interface{}) {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Panics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.Panics(t, f, msgAndArgs...) {
 		t.FailNow()
 	}
@@ -776,6 +1052,10 @@ func Panics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func PanicsWithValue(t TestingT, expected interface{}, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.PanicsWithValue(t, expected, f, msgAndArgs...) {
 		t.FailNow()
 	}
@@ -788,6 +1068,10 @@ func PanicsWithValue(t TestingT, expected interface{}, f assert.PanicTestFunc, m
 //
 // Returns whether the assertion was successful (true) or not (false).
 func PanicsWithValuef(t TestingT, expected interface{}, f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.PanicsWithValuef(t, expected, f, msg, args...) {
 		t.FailNow()
 	}
@@ -799,6 +1083,10 @@ func PanicsWithValuef(t TestingT, expected interface{}, f assert.PanicTestFunc, 
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Panicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.Panicsf(t, f, msg, args...) {
 		t.FailNow()
 	}
@@ -811,6 +1099,10 @@ func Panicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.Regexp(t, rx, str, msgAndArgs...) {
 		t.FailNow()
 	}
@@ -823,6 +1115,10 @@ func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.Regexpf(t, rx, str, msg, args...) {
 		t.FailNow()
 	}
@@ -835,6 +1131,10 @@ func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...in
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Subset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.Subset(t, list, subset, msgAndArgs...) {
 		t.FailNow()
 	}
@@ -847,6 +1147,10 @@ func Subset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...inte
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Subsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.Subsetf(t, list, subset, msg, args...) {
 		t.FailNow()
 	}
@@ -858,6 +1162,10 @@ func Subsetf(t TestingT, list interface{}, subset interface{}, msg string, args 
 //
 // Returns whether the assertion was successful (true) or not (false).
 func True(t TestingT, value bool, msgAndArgs ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.True(t, value, msgAndArgs...) {
 		t.FailNow()
 	}
@@ -869,6 +1177,10 @@ func True(t TestingT, value bool, msgAndArgs ...interface{}) {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Truef(t TestingT, value bool, msg string, args ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.Truef(t, value, msg, args...) {
 		t.FailNow()
 	}
@@ -880,6 +1192,10 @@ func Truef(t TestingT, value bool, msg string, args ...interface{}) {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func WithinDuration(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.WithinDuration(t, expected, actual, delta, msgAndArgs...) {
 		t.FailNow()
 	}
@@ -891,6 +1207,10 @@ func WithinDuration(t TestingT, expected time.Time, actual time.Time, delta time
 //
 // Returns whether the assertion was successful (true) or not (false).
 func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.WithinDurationf(t, expected, actual, delta, msg, args...) {
 		t.FailNow()
 	}
@@ -898,6 +1218,10 @@ func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta tim
 
 // Zero asserts that i is the zero value for its type and returns the truth.
 func Zero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.Zero(t, i, msgAndArgs...) {
 		t.FailNow()
 	}
@@ -905,6 +1229,10 @@ func Zero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
 
 // Zerof asserts that i is the zero value for its type and returns the truth.
 func Zerof(t TestingT, i interface{}, msg string, args ...interface{}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.Zerof(t, i, msg, args...) {
 		t.FailNow()
 	}

--- a/require/require.go.tmpl
+++ b/require/require.go.tmpl
@@ -1,5 +1,9 @@
 {{.Comment}}
 func {{.DocInfo.Name}}(t TestingT, {{.Params}}) {
+	if t, ok := t.(helper); ok {
+		t.Helper()
+	}
+
 	if !assert.{{.DocInfo.Name}}(t, {{.ForwardedParams}}) {
 		t.FailNow()
 	}

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -14,11 +14,19 @@ import (
 
 // Condition uses a Comparison to assert a complex condition.
 func (a *Assertions) Condition(comp assert.Comparison, msgAndArgs ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	Condition(a.t, comp, msgAndArgs...)
 }
 
 // Conditionf uses a Comparison to assert a complex condition.
 func (a *Assertions) Conditionf(comp assert.Comparison, msg string, args ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	Conditionf(a.t, comp, msg, args...)
 }
 
@@ -31,6 +39,10 @@ func (a *Assertions) Conditionf(comp assert.Comparison, msg string, args ...inte
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Contains(s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	Contains(a.t, s, contains, msgAndArgs...)
 }
 
@@ -43,6 +55,10 @@ func (a *Assertions) Contains(s interface{}, contains interface{}, msgAndArgs ..
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Containsf(s interface{}, contains interface{}, msg string, args ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	Containsf(a.t, s, contains, msg, args...)
 }
 
@@ -53,6 +69,10 @@ func (a *Assertions) Containsf(s interface{}, contains interface{}, msg string, 
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	Empty(a.t, object, msgAndArgs...)
 }
 
@@ -63,6 +83,10 @@ func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Emptyf(object interface{}, msg string, args ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	Emptyf(a.t, object, msg, args...)
 }
 
@@ -76,6 +100,10 @@ func (a *Assertions) Emptyf(object interface{}, msg string, args ...interface{})
 // referenced values (as opposed to the memory addresses). Function equality
 // cannot be determined and will always fail.
 func (a *Assertions) Equal(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	Equal(a.t, expected, actual, msgAndArgs...)
 }
 
@@ -87,6 +115,10 @@ func (a *Assertions) Equal(expected interface{}, actual interface{}, msgAndArgs 
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	EqualError(a.t, theError, errString, msgAndArgs...)
 }
 
@@ -98,6 +130,10 @@ func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) EqualErrorf(theError error, errString string, msg string, args ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	EqualErrorf(a.t, theError, errString, msg, args...)
 }
 
@@ -108,6 +144,10 @@ func (a *Assertions) EqualErrorf(theError error, errString string, msg string, a
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) EqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	EqualValues(a.t, expected, actual, msgAndArgs...)
 }
 
@@ -118,6 +158,10 @@ func (a *Assertions) EqualValues(expected interface{}, actual interface{}, msgAn
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) EqualValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	EqualValuesf(a.t, expected, actual, msg, args...)
 }
 
@@ -131,6 +175,10 @@ func (a *Assertions) EqualValuesf(expected interface{}, actual interface{}, msg 
 // referenced values (as opposed to the memory addresses). Function equality
 // cannot be determined and will always fail.
 func (a *Assertions) Equalf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	Equalf(a.t, expected, actual, msg, args...)
 }
 
@@ -143,6 +191,10 @@ func (a *Assertions) Equalf(expected interface{}, actual interface{}, msg string
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Error(err error, msgAndArgs ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	Error(a.t, err, msgAndArgs...)
 }
 
@@ -155,6 +207,10 @@ func (a *Assertions) Error(err error, msgAndArgs ...interface{}) {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Errorf(err error, msg string, args ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	Errorf(a.t, err, msg, args...)
 }
 
@@ -164,6 +220,10 @@ func (a *Assertions) Errorf(err error, msg string, args ...interface{}) {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Exactly(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	Exactly(a.t, expected, actual, msgAndArgs...)
 }
 
@@ -173,26 +233,46 @@ func (a *Assertions) Exactly(expected interface{}, actual interface{}, msgAndArg
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Exactlyf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	Exactlyf(a.t, expected, actual, msg, args...)
 }
 
 // Fail reports a failure through
 func (a *Assertions) Fail(failureMessage string, msgAndArgs ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	Fail(a.t, failureMessage, msgAndArgs...)
 }
 
 // FailNow fails test
 func (a *Assertions) FailNow(failureMessage string, msgAndArgs ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	FailNow(a.t, failureMessage, msgAndArgs...)
 }
 
 // FailNowf fails test
 func (a *Assertions) FailNowf(failureMessage string, msg string, args ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	FailNowf(a.t, failureMessage, msg, args...)
 }
 
 // Failf reports a failure through
 func (a *Assertions) Failf(failureMessage string, msg string, args ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	Failf(a.t, failureMessage, msg, args...)
 }
 
@@ -202,6 +282,10 @@ func (a *Assertions) Failf(failureMessage string, msg string, args ...interface{
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) False(value bool, msgAndArgs ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	False(a.t, value, msgAndArgs...)
 }
 
@@ -211,6 +295,10 @@ func (a *Assertions) False(value bool, msgAndArgs ...interface{}) {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Falsef(value bool, msg string, args ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	Falsef(a.t, value, msg, args...)
 }
 
@@ -221,6 +309,10 @@ func (a *Assertions) Falsef(value bool, msg string, args ...interface{}) {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPBodyContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	HTTPBodyContains(a.t, handler, method, url, values, str)
 }
 
@@ -231,6 +323,10 @@ func (a *Assertions) HTTPBodyContains(handler http.HandlerFunc, method string, u
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPBodyContainsf(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	HTTPBodyContainsf(a.t, handler, method, url, values, str)
 }
 
@@ -241,6 +337,10 @@ func (a *Assertions) HTTPBodyContainsf(handler http.HandlerFunc, method string, 
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPBodyNotContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	HTTPBodyNotContains(a.t, handler, method, url, values, str)
 }
 
@@ -251,6 +351,10 @@ func (a *Assertions) HTTPBodyNotContains(handler http.HandlerFunc, method string
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPBodyNotContainsf(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	HTTPBodyNotContainsf(a.t, handler, method, url, values, str)
 }
 
@@ -260,6 +364,10 @@ func (a *Assertions) HTTPBodyNotContainsf(handler http.HandlerFunc, method strin
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPError(handler http.HandlerFunc, method string, url string, values url.Values) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	HTTPError(a.t, handler, method, url, values)
 }
 
@@ -269,6 +377,10 @@ func (a *Assertions) HTTPError(handler http.HandlerFunc, method string, url stri
 //
 // Returns whether the assertion was successful (true, "error message %s", "formatted") or not (false).
 func (a *Assertions) HTTPErrorf(handler http.HandlerFunc, method string, url string, values url.Values) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	HTTPErrorf(a.t, handler, method, url, values)
 }
 
@@ -278,6 +390,10 @@ func (a *Assertions) HTTPErrorf(handler http.HandlerFunc, method string, url str
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPRedirect(handler http.HandlerFunc, method string, url string, values url.Values) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	HTTPRedirect(a.t, handler, method, url, values)
 }
 
@@ -287,6 +403,10 @@ func (a *Assertions) HTTPRedirect(handler http.HandlerFunc, method string, url s
 //
 // Returns whether the assertion was successful (true, "error message %s", "formatted") or not (false).
 func (a *Assertions) HTTPRedirectf(handler http.HandlerFunc, method string, url string, values url.Values) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	HTTPRedirectf(a.t, handler, method, url, values)
 }
 
@@ -296,6 +416,10 @@ func (a *Assertions) HTTPRedirectf(handler http.HandlerFunc, method string, url 
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPSuccess(handler http.HandlerFunc, method string, url string, values url.Values) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	HTTPSuccess(a.t, handler, method, url, values)
 }
 
@@ -305,6 +429,10 @@ func (a *Assertions) HTTPSuccess(handler http.HandlerFunc, method string, url st
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPSuccessf(handler http.HandlerFunc, method string, url string, values url.Values) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	HTTPSuccessf(a.t, handler, method, url, values)
 }
 
@@ -312,6 +440,10 @@ func (a *Assertions) HTTPSuccessf(handler http.HandlerFunc, method string, url s
 //
 //    a.Implements((*MyInterface)(nil), new(MyObject))
 func (a *Assertions) Implements(interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	Implements(a.t, interfaceObject, object, msgAndArgs...)
 }
 
@@ -319,6 +451,10 @@ func (a *Assertions) Implements(interfaceObject interface{}, object interface{},
 //
 //    a.Implementsf((*MyInterface, "error message %s", "formatted")(nil), new(MyObject))
 func (a *Assertions) Implementsf(interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	Implementsf(a.t, interfaceObject, object, msg, args...)
 }
 
@@ -328,16 +464,28 @@ func (a *Assertions) Implementsf(interfaceObject interface{}, object interface{}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) InDelta(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	InDelta(a.t, expected, actual, delta, msgAndArgs...)
 }
 
 // InDeltaSlice is the same as InDelta, except it compares two slices.
 func (a *Assertions) InDeltaSlice(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	InDeltaSlice(a.t, expected, actual, delta, msgAndArgs...)
 }
 
 // InDeltaSlicef is the same as InDelta, except it compares two slices.
 func (a *Assertions) InDeltaSlicef(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	InDeltaSlicef(a.t, expected, actual, delta, msg, args...)
 }
 
@@ -347,6 +495,10 @@ func (a *Assertions) InDeltaSlicef(expected interface{}, actual interface{}, del
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) InDeltaf(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	InDeltaf(a.t, expected, actual, delta, msg, args...)
 }
 
@@ -354,16 +506,28 @@ func (a *Assertions) InDeltaf(expected interface{}, actual interface{}, delta fl
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) InEpsilon(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	InEpsilon(a.t, expected, actual, epsilon, msgAndArgs...)
 }
 
 // InEpsilonSlice is the same as InEpsilon, except it compares each value from two slices.
 func (a *Assertions) InEpsilonSlice(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	InEpsilonSlice(a.t, expected, actual, epsilon, msgAndArgs...)
 }
 
 // InEpsilonSlicef is the same as InEpsilon, except it compares each value from two slices.
 func (a *Assertions) InEpsilonSlicef(expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	InEpsilonSlicef(a.t, expected, actual, epsilon, msg, args...)
 }
 
@@ -371,16 +535,28 @@ func (a *Assertions) InEpsilonSlicef(expected interface{}, actual interface{}, e
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) InEpsilonf(expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	InEpsilonf(a.t, expected, actual, epsilon, msg, args...)
 }
 
 // IsType asserts that the specified objects are of the same type.
 func (a *Assertions) IsType(expectedType interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	IsType(a.t, expectedType, object, msgAndArgs...)
 }
 
 // IsTypef asserts that the specified objects are of the same type.
 func (a *Assertions) IsTypef(expectedType interface{}, object interface{}, msg string, args ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	IsTypef(a.t, expectedType, object, msg, args...)
 }
 
@@ -390,6 +566,10 @@ func (a *Assertions) IsTypef(expectedType interface{}, object interface{}, msg s
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) JSONEq(expected string, actual string, msgAndArgs ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	JSONEq(a.t, expected, actual, msgAndArgs...)
 }
 
@@ -399,6 +579,10 @@ func (a *Assertions) JSONEq(expected string, actual string, msgAndArgs ...interf
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) JSONEqf(expected string, actual string, msg string, args ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	JSONEqf(a.t, expected, actual, msg, args...)
 }
 
@@ -409,6 +593,10 @@ func (a *Assertions) JSONEqf(expected string, actual string, msg string, args ..
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	Len(a.t, object, length, msgAndArgs...)
 }
 
@@ -419,6 +607,10 @@ func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Lenf(object interface{}, length int, msg string, args ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	Lenf(a.t, object, length, msg, args...)
 }
 
@@ -428,6 +620,10 @@ func (a *Assertions) Lenf(object interface{}, length int, msg string, args ...in
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Nil(object interface{}, msgAndArgs ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	Nil(a.t, object, msgAndArgs...)
 }
 
@@ -437,6 +633,10 @@ func (a *Assertions) Nil(object interface{}, msgAndArgs ...interface{}) {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Nilf(object interface{}, msg string, args ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	Nilf(a.t, object, msg, args...)
 }
 
@@ -449,6 +649,10 @@ func (a *Assertions) Nilf(object interface{}, msg string, args ...interface{}) {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NoError(err error, msgAndArgs ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	NoError(a.t, err, msgAndArgs...)
 }
 
@@ -461,6 +665,10 @@ func (a *Assertions) NoError(err error, msgAndArgs ...interface{}) {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NoErrorf(err error, msg string, args ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	NoErrorf(a.t, err, msg, args...)
 }
 
@@ -473,6 +681,10 @@ func (a *Assertions) NoErrorf(err error, msg string, args ...interface{}) {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotContains(s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	NotContains(a.t, s, contains, msgAndArgs...)
 }
 
@@ -485,6 +697,10 @@ func (a *Assertions) NotContains(s interface{}, contains interface{}, msgAndArgs
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotContainsf(s interface{}, contains interface{}, msg string, args ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	NotContainsf(a.t, s, contains, msg, args...)
 }
 
@@ -497,6 +713,10 @@ func (a *Assertions) NotContainsf(s interface{}, contains interface{}, msg strin
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	NotEmpty(a.t, object, msgAndArgs...)
 }
 
@@ -509,6 +729,10 @@ func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotEmptyf(object interface{}, msg string, args ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	NotEmptyf(a.t, object, msg, args...)
 }
 
@@ -521,6 +745,10 @@ func (a *Assertions) NotEmptyf(object interface{}, msg string, args ...interface
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
 func (a *Assertions) NotEqual(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	NotEqual(a.t, expected, actual, msgAndArgs...)
 }
 
@@ -533,6 +761,10 @@ func (a *Assertions) NotEqual(expected interface{}, actual interface{}, msgAndAr
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
 func (a *Assertions) NotEqualf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	NotEqualf(a.t, expected, actual, msg, args...)
 }
 
@@ -542,6 +774,10 @@ func (a *Assertions) NotEqualf(expected interface{}, actual interface{}, msg str
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotNil(object interface{}, msgAndArgs ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	NotNil(a.t, object, msgAndArgs...)
 }
 
@@ -551,6 +787,10 @@ func (a *Assertions) NotNil(object interface{}, msgAndArgs ...interface{}) {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotNilf(object interface{}, msg string, args ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	NotNilf(a.t, object, msg, args...)
 }
 
@@ -560,6 +800,10 @@ func (a *Assertions) NotNilf(object interface{}, msg string, args ...interface{}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotPanics(f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	NotPanics(a.t, f, msgAndArgs...)
 }
 
@@ -569,6 +813,10 @@ func (a *Assertions) NotPanics(f assert.PanicTestFunc, msgAndArgs ...interface{}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotPanicsf(f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	NotPanicsf(a.t, f, msg, args...)
 }
 
@@ -579,6 +827,10 @@ func (a *Assertions) NotPanicsf(f assert.PanicTestFunc, msg string, args ...inte
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	NotRegexp(a.t, rx, str, msgAndArgs...)
 }
 
@@ -589,6 +841,10 @@ func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...in
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotRegexpf(rx interface{}, str interface{}, msg string, args ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	NotRegexpf(a.t, rx, str, msg, args...)
 }
 
@@ -599,6 +855,10 @@ func (a *Assertions) NotRegexpf(rx interface{}, str interface{}, msg string, arg
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotSubset(list interface{}, subset interface{}, msgAndArgs ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	NotSubset(a.t, list, subset, msgAndArgs...)
 }
 
@@ -609,16 +869,28 @@ func (a *Assertions) NotSubset(list interface{}, subset interface{}, msgAndArgs 
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotSubsetf(list interface{}, subset interface{}, msg string, args ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	NotSubsetf(a.t, list, subset, msg, args...)
 }
 
 // NotZero asserts that i is not the zero value for its type and returns the truth.
 func (a *Assertions) NotZero(i interface{}, msgAndArgs ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	NotZero(a.t, i, msgAndArgs...)
 }
 
 // NotZerof asserts that i is not the zero value for its type and returns the truth.
 func (a *Assertions) NotZerof(i interface{}, msg string, args ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	NotZerof(a.t, i, msg, args...)
 }
 
@@ -628,6 +900,10 @@ func (a *Assertions) NotZerof(i interface{}, msg string, args ...interface{}) {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Panics(f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	Panics(a.t, f, msgAndArgs...)
 }
 
@@ -638,6 +914,10 @@ func (a *Assertions) Panics(f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) PanicsWithValue(expected interface{}, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	PanicsWithValue(a.t, expected, f, msgAndArgs...)
 }
 
@@ -648,6 +928,10 @@ func (a *Assertions) PanicsWithValue(expected interface{}, f assert.PanicTestFun
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) PanicsWithValuef(expected interface{}, f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	PanicsWithValuef(a.t, expected, f, msg, args...)
 }
 
@@ -657,6 +941,10 @@ func (a *Assertions) PanicsWithValuef(expected interface{}, f assert.PanicTestFu
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Panicsf(f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	Panicsf(a.t, f, msg, args...)
 }
 
@@ -667,6 +955,10 @@ func (a *Assertions) Panicsf(f assert.PanicTestFunc, msg string, args ...interfa
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	Regexp(a.t, rx, str, msgAndArgs...)
 }
 
@@ -677,6 +969,10 @@ func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...inter
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Regexpf(rx interface{}, str interface{}, msg string, args ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	Regexpf(a.t, rx, str, msg, args...)
 }
 
@@ -687,6 +983,10 @@ func (a *Assertions) Regexpf(rx interface{}, str interface{}, msg string, args .
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Subset(list interface{}, subset interface{}, msgAndArgs ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	Subset(a.t, list, subset, msgAndArgs...)
 }
 
@@ -697,6 +997,10 @@ func (a *Assertions) Subset(list interface{}, subset interface{}, msgAndArgs ...
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Subsetf(list interface{}, subset interface{}, msg string, args ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	Subsetf(a.t, list, subset, msg, args...)
 }
 
@@ -706,6 +1010,10 @@ func (a *Assertions) Subsetf(list interface{}, subset interface{}, msg string, a
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) True(value bool, msgAndArgs ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	True(a.t, value, msgAndArgs...)
 }
 
@@ -715,6 +1023,10 @@ func (a *Assertions) True(value bool, msgAndArgs ...interface{}) {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Truef(value bool, msg string, args ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	Truef(a.t, value, msg, args...)
 }
 
@@ -724,6 +1036,10 @@ func (a *Assertions) Truef(value bool, msg string, args ...interface{}) {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) WithinDuration(expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	WithinDuration(a.t, expected, actual, delta, msgAndArgs...)
 }
 
@@ -733,15 +1049,27 @@ func (a *Assertions) WithinDuration(expected time.Time, actual time.Time, delta 
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) WithinDurationf(expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	WithinDurationf(a.t, expected, actual, delta, msg, args...)
 }
 
 // Zero asserts that i is the zero value for its type and returns the truth.
 func (a *Assertions) Zero(i interface{}, msgAndArgs ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	Zero(a.t, i, msgAndArgs...)
 }
 
 // Zerof asserts that i is the zero value for its type and returns the truth.
 func (a *Assertions) Zerof(i interface{}, msg string, args ...interface{}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	Zerof(a.t, i, msg, args...)
 }

--- a/require/require_forward.go.tmpl
+++ b/require/require_forward.go.tmpl
@@ -1,4 +1,8 @@
 {{.CommentWithoutT "a"}}
 func (a *Assertions) {{.DocInfo.Name}}({{.Params}}) {
+	if t, ok := a.t.(helper); ok {
+		t.Helper()
+	}
+
 	{{.DocInfo.Name}}(a.t, {{.ForwardedParams}})
 }

--- a/require/requirements.go
+++ b/require/requirements.go
@@ -6,4 +6,8 @@ type TestingT interface {
 	FailNow()
 }
 
+type helper interface {
+	Helper()
+}
+
 //go:generate go run ../_codegen/main.go -output-package=require -template=require.go.tmpl -include-format-funcs


### PR DESCRIPTION
See https://golang.org/pkg/testing/#T.Helper for documentation of this new method.

On go >= 1.9 this allows to mark assert/require functions as test helper functions and get the proper trace without further work.

On go < 1.9 the previous behaviour (manual computation of caller info, added to the message log) is kept.